### PR TITLE
Docker Security 🔒

### DIFF
--- a/src/caddy/Dockerfile
+++ b/src/caddy/Dockerfile
@@ -1,8 +1,13 @@
 FROM caddy/caddy:2.4.6-alpine
 
-RUN mkdir /app
-COPY start.sh /app/start.sh
+RUN adduser -D nonroot -u 10001
 
-COPY Caddyfile /etc/caddy/Caddyfile
+RUN mkdir /app
+COPY --chown=nonroot:nonroot start.sh /app/start.sh
+COPY --chown=nonroot:nonroot Caddyfile /etc/caddy/Caddyfile
+
+RUN chown -R nonroot:nonroot /app
+
+USER nonroot
 
 CMD ["sh", "/app/start.sh"]

--- a/src/status_page/Dockerfile
+++ b/src/status_page/Dockerfile
@@ -1,1 +1,1 @@
-FROM louislam/uptime-kuma:1.15.0-alpine
+FROM louislam/uptime-kuma:1.15.1-alpine


### PR DESCRIPTION
# Docker Security 🔒 

This pull request ensure that the `Caddy` container runs as the `nonroot` user for added security measures