### PR TITLE
create cache rule for custom api route

### DIFF
--- a/src/caddy/Caddyfile
+++ b/src/caddy/Caddyfile
@@ -1,5 +1,17 @@
 {$DOMAIN} {
-  reverse_proxy {$PROXY_BACKEND}:{$PROXY_PORT}  {
-    header_down Strict-Transport-Security max-age=31536000;
+
+  # Custom API route for external services, cached
+  handle /api/status-page/heartbeat/api {
+    header Cache-Control "public, max-age=300"
+    reverse_proxy {$PROXY_BACKEND}:{$PROXY_PORT}  {
+      header_down Strict-Transport-Security max-age=31536000;
+    }
+  }
+
+  # All other paths are proxied to the backend
+  handle /* {
+    reverse_proxy {$PROXY_BACKEND}:{$PROXY_PORT}  {
+      header_down Strict-Transport-Security max-age=31536000;
+    }
   }
 }

--- a/src/caddy/Caddyfile
+++ b/src/caddy/Caddyfile
@@ -3,6 +3,7 @@
   # Custom API route for external services, cached
   handle /api/status-page/heartbeat/api {
     header Cache-Control "public, max-age=300"
+    header Access-Control-Allow-Origin "*"
     encode {
 		  gzip 9
 	  }

--- a/src/caddy/Caddyfile
+++ b/src/caddy/Caddyfile
@@ -3,6 +3,9 @@
   # Custom API route for external services, cached
   handle /api/status-page/heartbeat/api {
     header Cache-Control "public, max-age=300"
+    encode {
+		  gzip 9
+	  }
     reverse_proxy {$PROXY_BACKEND}:{$PROXY_PORT}  {
       header_down Strict-Transport-Security max-age=31536000;
     }


### PR DESCRIPTION
Setting up and exposing a new API endpoint from the status service that will be cached for 5 minutes and return metrics about how the API is performing so it can be monitored by other services!

related: https://github.com/the-hideout/cloudflare/pull/51