### PR TITLE
bump to `v1.23.11`

### DIFF
--- a/src/status_page/Dockerfile
+++ b/src/status_page/Dockerfile
@@ -1,1 +1,1 @@
-FROM louislam/uptime-kuma:1.23.10-alpine
+FROM louislam/uptime-kuma:1.23.11-alpine


### PR DESCRIPTION
upgrade to the latest version: https://github.com/louislam/uptime-kuma/releases/tag/1.23.11