### PR TITLE
Pin GitHub Actions to SHAs

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: github/branch-deploy@v9.1.1
+      - uses: github/branch-deploy@4c2569bad1865c45e0be37b5e06ee5a6b805a93e # pin@v9.1.1
         id: branch-deploy
         with:
           admins: the-hideout/core-contributors
@@ -29,7 +29,7 @@ jobs:
 
       - name: checkout
         if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
         with:
           ref: ${{ steps.branch-deploy.outputs.ref }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
 
       - uses: azure/login@8c334a195cbb38e46038007b304988d888bf676a # pin@v1
         with:

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -15,9 +15,9 @@ jobs:
 
     steps:
       # Comment on new PR requests with deployment instructions
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: comment
-        uses: GrantBirki/comment@v2.0.9
+        uses: GrantBirki/comment@d5cdf0243751ca01060946b2cae3722e508b7b16 # pin@v2.0.9
         continue-on-error: true
         with:
           file: .github/new-pr-comment.md

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: unlock on merge
-        uses: github/branch-deploy@v9.1.1
+        uses: github/branch-deploy@4c2569bad1865c45e0be37b5e06ee5a6b805a93e # pin@v9.1.1
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow


### PR DESCRIPTION
## Summary
- Pin workflow `uses:` refs to full-length commit SHAs
- Remove the retired Combine PR workflow when present
- Preserve readable source refs in `# pin@...` comments

## Test
- Verified via GitHub API scan that workflow `uses:` refs on this branch are pinned to full-length SHAs
